### PR TITLE
exercise1 

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,9 @@
 var assert = require('assert')
 
-describe('Array', function() {
-  describe('#indexOf()', function() {
-    it('should return -1 when the value is not present', function() {
-      assert.equal(-1, [1, 2, 3]/* 填空题 */)
+describe('Array', function () {
+  describe('#indexOf()', function () {
+    it('should return -1 when the value is not present', function () {
+      assert.equal(-1, [1, 2, 3].indexOf(5));
     })
   })
 })
@@ -21,7 +21,7 @@ describe('assert', function () {
       }
     }
     // 修改下面代码使得满足测试描述
-    assert.equal(a, b)
+    assert.deepEqual(a, b)
   })
 
   it('可以捕获并验证函数fn的错误', function () {
@@ -29,6 +29,10 @@ describe('assert', function () {
       xxx;
     }
     // 修改下面代码使得满足测试描述
-    fn()
+
+    assert.throws(
+      fn,
+      /xxx is not defined/
+    )
   })
 })


### PR DESCRIPTION
之前第三个测试用例一直编译不通过，比对了下发现是assert.throws()的第一个参数  传了fn()  传递的是fn函数的返回值  而不是fn的指针   